### PR TITLE
Update build.sbt with silhouette version 5.0.4 to fix logging issue

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ lazy val `play-silhouette-rest-slick` = (project in file(".")).enablePlugins(Pla
 scalacOptions ++= Seq("-deprecation", "-language:_")
 
 scalaVersion := "2.12.6"
-val silhouetteVersion = "5.0.3"
+val silhouetteVersion = "5.0.4"
 val playMailerVersion = "6.0.1"
 val playJsonVersion = "2.6.8"
 val swaggerUIVersion = "3.6.1"


### PR DESCRIPTION
Fixes an issue document here which prevents logs from showing up:

https://stackoverflow.com/questions/52921252/play-2-6x-scala-app-does-not-log-despite-logback-configuration